### PR TITLE
updated to the new auth flow

### DIFF
--- a/sample_client_secret.py
+++ b/sample_client_secret.py
@@ -1,4 +1,5 @@
-from cognite.client import CogniteClient
+from cognite.client import CogniteClient, ClientConfig
+from cognite.client.credentials import OAuthClientCredentials
 import os
 
 # Contact Project Administrator to get these
@@ -13,15 +14,10 @@ CLIENT_SECRET = os.getenv("CLIENT_SECRET")  # store secret in env variable
 
 TOKEN_URL = f"https://login.microsoftonline.com/{TENANT_ID}/oauth2/v2.0/token"
 
-client = CogniteClient(
-    token_url=TOKEN_URL,
-    token_client_id=CLIENT_ID,
-    token_client_secret=CLIENT_SECRET,
-    token_scopes=SCOPES,
-    project=COGNITE_PROJECT,
-    base_url=f"https://{CDF_CLUSTER}.cognitedata.com",
-    client_name="client_secret_test_script",
-    debug=True,
-)
+creds=OAuthClientCredentials(token_url=TOKEN_URL, client_id= CLIENT_ID, scopes= SCOPES, client_secret= CLIENT_SECRET)
+
+cnf = ClientConfig(client_name="my-special-client", project=COGNITE_PROJECT, credentials=creds)
+
+client = CogniteClient(cnf)
 
 print(client.iam.token.inspect())

--- a/sample_device_code.py
+++ b/sample_device_code.py
@@ -1,4 +1,5 @@
-from cognite.client import CogniteClient
+from cognite.client import CogniteClient, ClientConfig
+from cognite.client.credentials import Token
 from msal import PublicClientApplication
 
 # Contact Project Administrator to get these
@@ -26,13 +27,7 @@ def authenticate_device_code():
 
 creds = authenticate_device_code()
 
-client = CogniteClient(
-    token_url=creds["id_token_claims"]["iss"],
-    token=creds["access_token"],
-    token_client_id=creds["id_token_claims"]["aud"],
-    project=COGNITE_PROJECT,
-    base_url=f"https://{CDF_CLUSTER}.cognitedata.com",
-    client_name="cognite-python-dev",
-)
+cnf = ClientConfig(client_name="my-special-client", project="my-project", credentials=Token(creds["access_token"]))
+client = CogniteClient(cnf)
 
 print(client.iam.token.inspect())

--- a/sample_device_code_token_refresh.py
+++ b/sample_device_code_token_refresh.py
@@ -1,4 +1,5 @@
-from cognite.client import CogniteClient
+from cognite.client import CogniteClient, ClientConfig
+from cognite.client.credentials import Token
 from msal import PublicClientApplication
 
 # Contact Project Administrator to get these
@@ -31,12 +32,7 @@ def get_token():
     return authenticate_device_code(app)["access_token"]
 
 
-client = CogniteClient(
-    token_url=f"{AUTHORITY_URI}/v2.0",
-    token=get_token,
-    token_client_id=CLIENT_ID,
-    project=COGNITE_PROJECT,
-    base_url=f"https://{CDF_CLUSTER}.cognitedata.com",
-    client_name="cognite-python-dev",
-)
+cnf = ClientConfig(client_name="my-special-client", project="my-project", credentials=Token(get_token))
+client = CogniteClient(cnf)
+
 print(client.iam.token.inspect())

--- a/sample_interactive_login.py
+++ b/sample_interactive_login.py
@@ -1,4 +1,5 @@
-from cognite.client import CogniteClient
+from cognite.client import CogniteClient, ClientConfig
+from cognite.client.credentials import Token
 from msal import PublicClientApplication
 
 # Contact Project Administrator to get these
@@ -25,13 +26,8 @@ def authenticate_azure():
 
 creds = authenticate_azure()
 
-client = CogniteClient(
-    token_url=creds["id_token_claims"]["iss"],
-    token=creds["access_token"],
-    token_client_id=creds["id_token_claims"]["aud"],
-    project=COGNITE_PROJECT,
-    base_url=f"https://{CDF_CLUSTER}.cognitedata.com",
-    client_name="cognite-python-dev",
-)
+cnf = ClientConfig(client_name="my-special-client", project="my-project", credentials=Token(creds["access_token"]))
+client = CogniteClient(cnf)
+
 
 print(client.iam.token.inspect())

--- a/sample_interactive_login_token_refresh.py
+++ b/sample_interactive_login_token_refresh.py
@@ -1,7 +1,8 @@
 import atexit
 import os
 
-from cognite.client import CogniteClient
+from cognite.client import CogniteClient, ClientConfig
+from cognite.client.credentials import Token
 from msal import PublicClientApplication, SerializableTokenCache
 
 # Contact Project Administrator to get these
@@ -47,14 +48,7 @@ def get_token():
     return authenticate_azure(app)["access_token"]
 
 
-client = CogniteClient(
-    token_url=f"{AUTHORITY_URI}/v2.0",
-    token=get_token,
-    token_client_id=CLIENT_ID,
-    project=COGNITE_PROJECT,
-    base_url=f"https://{CDF_CLUSTER}.cognitedata.com",
-    client_name="cognite-python-dev",
-    debug=True,
-)
+cnf = ClientConfig(client_name="my-special-client", project="my-project", credentials=Token(get_token))
+client = CogniteClient(cnf)
 
 print(client.iam.token.inspect())


### PR DESCRIPTION
Auth has been reworked. The client configuration no longer accepts the api_key and token_... arguments. It accepts only a single credentials argument which must be a CredentialProvider object. A few implementations have been provided (Token, OAuthClientCredentials). The samples are updated accordingly.